### PR TITLE
Analytic KL term, misc example clean up

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ The results can be reproduced by running
 
 .. code-block:: bash
 
-  python examples/iw_vae.py -eqsamples 1 -iw_samples 1 -lr 0.001 -nhidden 500 -nlatent 100 -nonlin_dec very_leaky_rectify -nonlin_enc rectify
+  python examples/iw_vae.py -eq_samples 1 -iw_samples 1 -lr 0.001 -nhidden 500 -nlatent 100 -nonlin_dec very_leaky_rectify -nonlin_enc rectify
 
 
 Development

--- a/examples/iw_vae.py
+++ b/examples/iw_vae.py
@@ -175,7 +175,7 @@ def latent_gaussian_x_bernoulli(z, z_mu, z_log_var, x_mu, x, eq_samples, iw_samp
 
     # dimshuffle x since we need to broadcast it when calculationg the binary
     # cross-entropy
-    x = x.dimshuffle(0,'x','x',1) # x: (batch_size, nsamples, ivae_samples, num_latent)
+    x = x.dimshuffle(0,'x','x',1) # x: (batch_size, eq_samples, iw_samples, num_latent)
 
     #calculate LL components, note that we sum over the feature/num_unit dimension
     z_mu = z_mu.dimshuffle(0,'x','x',1) # mean: (batch_size, num_latent)

--- a/examples/iw_vae.py
+++ b/examples/iw_vae.py
@@ -7,6 +7,7 @@ matplotlib.use('Agg')
 import theano.tensor as T
 import numpy as np
 import lasagne
+from parmesan.distributions import log_stdnormal, log_normal2, log_bernoulli
 from parmesan.layers import SampleLayer
 from parmesan.datasets import load_mnist_realval, load_mnist_binarized
 import matplotlib.pyplot as plt
@@ -15,7 +16,7 @@ import shutil, gzip, os, cPickle, time, math, operator, argparse
 parser = argparse.ArgumentParser()
 parser.add_argument("-dataset", type=str,
         help="real or binarized MNIST, real|binarized", default="real")
-parser.add_argument("-eqsamples", type=int,
+parser.add_argument("-eq_samples", type=int,
         help="samples over Eq", default=1)
 parser.add_argument("-iw_samples", type=int,
         help="iw_samples", default=1)
@@ -49,8 +50,8 @@ def get_nonlin(nonlin):
     else:
         raise ValueError()
 
-iw_samples = args.iw_samples   #number of MC samples over the expectation over E_q(z|x)
-eq_samples = args.eqsamples    #number of importance weighted samples
+iw_samples = args.iw_samples   #number of importance weighted samples
+eq_samples = args.eq_samples   #number of MC samples over the expectation over E_q(z|x)
 lr = args.lr
 res_out = args.outfolder
 nonlin_enc = get_nonlin(args.nonlin_enc)
@@ -64,6 +65,8 @@ batch_size_test = 50
 eval_epoch = args.eval_epoch
 
 assert dataset in ['real','binarized'], "dataset must be real|binarized"
+
+np.random.seed(1234) # reproducibility
 
 ### SET UP LOGFILE AND OUTPUT FOLDER
 if not os.path.exists(res_out):
@@ -93,24 +96,6 @@ sym_iw_samples = T.iscalar('iw_samples')
 sym_eq_samples = T.iscalar('eq_samples')
 sym_lr = T.scalar('lr')
 sym_x = T.matrix('x')
-
-
-c = - 0.5 * math.log(2*math.pi)
-def normal(x, mean, sd):
-    return c - T.log(T.abs_(sd)) - (x - mean)**2 / (2 * sd**2)
-
-def normal2(x, mean, logvar):
-    '''
-    x: (batch_size, nsamples, ivae_samples, num_latent)
-    mean: (batch_size, num_latent)
-    logvar: (batch_size, num_latent)
-    '''
-    mean = mean.dimshuffle(0,'x','x',1)
-    logvar = logvar.dimshuffle(0,'x','x',1)
-    return c - logvar/2 - (x - mean)**2 / (2 * T.exp(logvar))
-
-def standard_normal(x):
-    return c - x**2 / 2
 
 
 def bernoullisample(x):
@@ -190,12 +175,14 @@ def latent_gaussian_x_bernoulli(z, z_mu, z_log_var, x_mu, x, eq_samples, iw_samp
 
     # dimshuffle x since we need to broadcast it when calculationg the binary
     # cross-entropy
-    x = x.dimshuffle((0,'x','x',1))
+    x = x.dimshuffle(0,'x','x',1) # x: (batch_size, nsamples, ivae_samples, num_latent)
 
     #calculate LL components, note that we sum over the feature/num_unit dimension
-    log_qz_given_x = normal2(z, z_mu, z_log_var).sum(axis=3)
-    log_pz = standard_normal(z).sum(axis=3)
-    log_px_given_z = T.sum(-T.nnet.binary_crossentropy(T.clip(x_mu,epsilon,1-epsilon), x), axis=3)
+    z_mu = z_mu.dimshuffle(0,'x','x',1) # mean: (batch_size, num_latent)
+    z_log_var = z_log_var.dimshuffle(0,'x','x',1) # logvar: (batch_size, num_latent)
+    log_qz_given_x = log_normal2(z, z_mu, z_log_var).sum(axis=3)
+    log_pz = log_stdnormal(z).sum(axis=3)
+    log_px_given_z = log_bernoulli(x, T.clip(x_mu,epsilon,1-epsilon)).sum(axis=3)
 
     #all log_*** should have dimension (batch_size, eq_samples, iw_samples)
     # Calculate the LL using log-sum-exp to avoid underflow

--- a/examples/iw_vae_normflow.py
+++ b/examples/iw_vae_normflow.py
@@ -9,6 +9,7 @@ matplotlib.use('Agg')
 import theano.tensor as T
 import numpy as np
 import lasagne
+from parmesan.distributions import log_stdnormal, log_normal2, log_bernoulli
 from parmesan.layers import SampleLayer, NormalizingPlanarFlowLayer, ListIndexLayer
 from parmesan.datasets import load_mnist_realval, load_mnist_binarized
 import matplotlib.pyplot as plt
@@ -17,7 +18,7 @@ import shutil, gzip, os, cPickle, time, math, operator, argparse
 parser = argparse.ArgumentParser()
 parser.add_argument("-dataset", type=str,
         help="real or binarized MNIST, real|binarized", default="real")
-parser.add_argument("-eqsamples", type=int,
+parser.add_argument("-eq_samples", type=int,
         help="samples over Eq", default=1)
 parser.add_argument("-iw_samples", type=int,
         help="iw_samples", default=1)
@@ -53,8 +54,8 @@ def get_nonlin(nonlin):
     else:
         raise ValueError()
 
-iw_samples = args.iw_samples   #number of MC samples over the expectation over E_q(z|x)
-eq_samples = args.eqsamples    #number of importance weighted samples
+iw_samples = args.iw_samples   #number of importance weighted samples
+eq_samples = args.eq_samples   #number of MC samples over the expectation over E_q(z|x)
 lr = args.lr
 res_out = args.outfolder
 nonlin_enc = get_nonlin(args.nonlin_enc)
@@ -69,6 +70,8 @@ batch_size_test = 50
 eval_epoch = args.eval_epoch
 
 assert dataset in ['real','binarized'], "dataset must be real|binarized"
+
+np.random.seed(1234) # reproducibility
 
 ### SET UP LOGFILE AND OUTPUT FOLDER
 if not os.path.exists(res_out):
@@ -99,23 +102,6 @@ sym_eq_samples = T.iscalar('eq_samples')
 sym_lr = T.scalar('lr')
 sym_x = T.matrix('x')
 
-
-c = - 0.5 * math.log(2*math.pi)
-def normal(x, mean, sd):
-    return c - T.log(T.abs_(sd)) - (x - mean)**2 / (2 * sd**2)
-
-def normal2(x, mean, logvar):
-    '''
-    x: (batch_size, nsamples, ivae_samples, num_latent)
-    mean: (batch_size, num_latent)
-    logvar: (batch_size, num_latent)
-    '''
-    mean = mean.dimshuffle(0,'x','x',1)
-    logvar = logvar.dimshuffle(0,'x','x',1)
-    return c - logvar/2 - (x - mean)**2 / (2 * T.exp(logvar))
-
-def standard_normal(x):
-    return c - x**2 / 2
 
 def bernoullisample(x):
     return np.random.binomial(1,x,size=x.shape).astype(theano.config.floatX)
@@ -211,16 +197,18 @@ def latent_gaussian_x_bernoulli(z, z_mu, psi_u_list, z_log_var, x_mu, x, eq_samp
 
     # dimshuffle x since we need to broadcast it when calculationg the binary
     # cross-entropy
-    x = x.dimshuffle((0,'x','x',1))
+    x = x.dimshuffle(0,'x','x',1) # x: (batch_size, nsamples, ivae_samples, num_latent)
 
     for i in range(len(psi_u_list)):
         psi_u_list[i] = psi_u_list[i].reshape((-1, eq_samples, iw_samples))
 
 
     #calculate LL components, note that we sum over the feature/num_unit dimension
-    log_qz_given_x = normal2(z, z_mu, z_log_var).sum(axis=3)
-    log_pz = standard_normal(z).sum(axis=3)
-    log_px_given_z = T.sum(-T.nnet.binary_crossentropy(T.clip(x_mu,epsilon,1-epsilon), x), axis=3)
+    z_mu = z_mu.dimshuffle(0,'x','x',1) # mean: (batch_size, num_latent)
+    z_log_var = z_log_var.dimshuffle(0,'x','x',1) # logvar: (batch_size, num_latent)
+    log_qz_given_x = log_normal2(z, z_mu, z_log_var).sum(axis=3)
+    log_pz = log_stdnormal(z).sum(axis=3)
+    log_px_given_z = log_bernoulli(x, T.clip(x_mu,epsilon,1-epsilon)).sum(axis=3)
 
     #normalizing flow loss
     sum_log_psiu = 0

--- a/examples/iw_vae_normflow.py
+++ b/examples/iw_vae_normflow.py
@@ -197,7 +197,7 @@ def latent_gaussian_x_bernoulli(z, z_mu, psi_u_list, z_log_var, x_mu, x, eq_samp
 
     # dimshuffle x since we need to broadcast it when calculationg the binary
     # cross-entropy
-    x = x.dimshuffle(0,'x','x',1) # x: (batch_size, nsamples, ivae_samples, num_latent)
+    x = x.dimshuffle(0,'x','x',1) # x: (batch_size, eq_samples, iw_samples, num_latent)
 
     for i in range(len(psi_u_list)):
         psi_u_list[i] = psi_u_list[i].reshape((-1, eq_samples, iw_samples))

--- a/examples/mnist_ladder.py
+++ b/examples/mnist_ladder.py
@@ -82,6 +82,8 @@ num_classes = 10
 batch_size = 100  # fails if batch_size != batch_size
 num_labels = 100
 
+np.random.seed(1234) # reproducibility
+
 output_folder = "logs/mnist_ladder" + str(uuid.uuid4())[:18].replace('-', '_')
 if not os.path.exists(output_folder):
     os.makedirs(output_folder)

--- a/examples/vae_vanilla.py
+++ b/examples/vae_vanilla.py
@@ -12,11 +12,11 @@ import time, shutil, os
 
 
 #settings
-batch_size = 250
-nhidden = 100
-latent_size = 250
+batch_size = 128
+nhidden = 500
+latent_size = 100
 analytic_kl_term = False
-lr = 0.005
+lr = 0.001
 num_epochs = 1000
 results_out = 'results/vae_vanilla/'
 

--- a/parmesan/distributions.py
+++ b/parmesan/distributions.py
@@ -4,16 +4,118 @@ import theano.tensor as T
 
 c = - 0.5 * math.log(2*math.pi)
 def log_normal(x, mean, sd):
+    """
+    Compute log pdf of a Gaussian distribution with digonal covariance, at values x.
+
+        .. math:: \log p(x) = \log \mathcal{N}(x; \mu, I\sigma^2)
+    
+    Parameters
+    ----------
+    x : Theano tensor
+        Values at which to evaluate pdf.
+    mean : Theano tensor
+        Mean of the Gaussian distribution.
+    sd : Theano tensor
+        Standard deviation of the diagonal covariance Gaussian.
+
+    Returns
+    -------
+    Theano tensor
+        Element-wise log probability, this has to be summed for multi-variate distributions.
+    """
     return c - T.log(T.abs_(sd)) - (x - mean)**2 / (2 * sd**2)
 
 def log_normal2(x, mean, logvar):
+    """
+    Compute log pdf of a Gaussian distribution with digonal covariance, at values x.
+    Here variance is parameterized in the log domain, which ensures :math:`\sigma > 0`.
+
+        .. math:: \log p(x) = \log \mathcal{N}(x; \mu, I\sigma^2)
+    
+    Parameters
+    ----------
+    x : Theano tensor
+        Values at which to evaluate pdf.
+    mean : Theano tensor
+        Mean of the Gaussian distribution.
+    logvar : Theano tensor
+        Log variance of the diagonal covariance Gaussian.
+
+    Returns
+    -------
+    Theano tensor
+        Element-wise log probability, this has to be summed for multi-variate distributions.
+    """
     return c - logvar/2 - (x - mean)**2 / (2 * T.exp(logvar))
 
 def log_stdnormal(x):
+    """
+    Compute log pdf of a standard Gaussian distribution with zero mean and unit variance, at values x.
+
+        .. math:: \log p(x) = \log \mathcal{N}(x; 0, I)
+    
+    Parameters
+    ----------
+    x : Theano tensor
+        Values at which to evaluate pdf.
+
+    Returns
+    -------
+    Theano tensor
+        Element-wise log probability, this has to be summed for multi-variate distributions.
+    """
     return c - x**2 / 2
 
 def log_bernoulli(x, p):
+    """
+    Compute log pdf of a Bernoulli distribution with success probability p, at values x.
+
+        .. math:: \log p(x; p) = \log \mathcal{B}(x; p)
+
+    Parameters
+    ----------
+    x : Theano tensor
+        Values at which to evaluate pdf.
+    p : Theano tensor
+        Success probability :math:`p(x=1)`, which is also the mean of the Bernoulli distribution.
+
+    Returns
+    -------
+    Theano tensor
+        Element-wise log probability, this has to be summed for multi-variate distributions.
+    """
     return -T.nnet.binary_crossentropy(p, x)
 
 def kl_normal2_stdnormal(mean, logvar):
+    """
+    Compute analytically integrated KL-divergence between a diagonal covariance Gaussian and 
+    a standard Gaussian.
+
+    In the setting of the variational auto-encoder, when a Gaussian prior and diagonal Gaussian 
+    approximate posterior is used, this analytically integrated KL-divergence term yields a lower variance 
+    estimate of the likelihood lower bound compared to computing the term by Monte Carlo approxmation.
+
+        .. math:: D_{KL}[q_{\phi}(z|x) || p_{\theta}(z)]
+
+    See appendix D of [KINGMA]_ for details.
+
+    Parameters
+    ----------
+    mean : Theano tensor
+        Mean of the diagonal covariance Gaussian.
+    logvar : Theano tensor
+        Log variance of the diagonal covariance Gaussian.
+
+    Returns
+    -------
+    Theano tensor
+        Element-wise KL-divergence, this has to be summed when the Gaussian distributions are multi-variate.
+
+    References
+    ----------
+        ..  [KINGMA] Kingma, Diederik P., and Max Welling.
+            "Auto-encoding variational bayes."
+            arXiv preprint arXiv:1312.6114 (2013).
+
+    """
     return -0.5*(1 + logvar - mean**2 - T.exp(logvar))

--- a/parmesan/distributions.py
+++ b/parmesan/distributions.py
@@ -3,11 +3,17 @@ import theano.tensor as T
 
 
 c = - 0.5 * math.log(2*math.pi)
-def lognormal(x, mean, sd):
+def log_normal(x, mean, sd):
     return c - T.log(T.abs_(sd)) - (x - mean)**2 / (2 * sd**2)
 
-def lognormal2(x, mean, logvar):
+def log_normal2(x, mean, logvar):
     return c - logvar/2 - (x - mean)**2 / (2 * T.exp(logvar))
 
-def logstandard_normal(x):
+def log_stdnormal(x):
     return c - x**2 / 2
+
+def log_bernoulli(x, p):
+    return -T.nnet.binary_crossentropy(p, x)
+
+def kl_normal2_stdnormal(mean, logvar):
+    return -0.5*(1 + logvar - mean**2 - T.exp(logvar))


### PR DESCRIPTION
- Added option for analytically integrated KL divergence term in vae_vanilla.py
(lower variance estimator of lower bound compared to using Monte Carlo
approximation, see Kingma et al.)
- Slightly modified names in distributions.py
- Added fixed numpy random seed to all examples for reproducibility
- Few minor clean-ups in examples