### PR TITLE
Cleaned up examples a little

### DIFF
--- a/examples/iw_vae.py
+++ b/examples/iw_vae.py
@@ -13,13 +13,15 @@ from parmesan.datasets import load_mnist_realval, load_mnist_binarized
 import matplotlib.pyplot as plt
 import shutil, gzip, os, cPickle, time, math, operator, argparse
 
+filename_script = os.path.basename(os.path.realpath(__file__))
+
 parser = argparse.ArgumentParser()
 parser.add_argument("-dataset", type=str,
         help="sampled or fixed binarized MNIST, sample|fixed", default="sample")
 parser.add_argument("-eq_samples", type=int,
-        help="samples over Eq", default=1)
+        help="number of samples for the expectation over q(z|x)", default=1)
 parser.add_argument("-iw_samples", type=int,
-        help="iw_samples", default=1)
+        help="number of importance weighted samples", default=1)
 parser.add_argument("-lr", type=float,
         help="learning rate", default=0.001)
 parser.add_argument("-anneal_lr_factor", type=float,
@@ -29,17 +31,19 @@ parser.add_argument("-anneal_lr_epoch", type=float,
 parser.add_argument("-batch_norm", type=str,
         help="batch normalization", default='true')
 parser.add_argument("-outfolder", type=str,
-        help="outfolder", default="outfolder")
+        help="output folder", default=os.path.join("results", os.path.splitext(filename_script)[0]))
 parser.add_argument("-nonlin_enc", type=str,
-        help="nonlin encoder", default="rectify")
+        help="encoder non-linearity", default="rectify")
 parser.add_argument("-nonlin_dec", type=str,
-        help="nonlin decoder", default="rectify")
+        help="decoder non-linearity", default="rectify")
 parser.add_argument("-nhidden", type=int,
-        help="number of hidden units in determistic layers", default=500)
+        help="number of hidden units in deterministic layers", default=500)
 parser.add_argument("-nlatent", type=int,
         help="number of stochastic latent units", default=100)
 parser.add_argument("-batch_size", type=int,
         help="batch size", default=100)
+parser.add_argument("-nepochs", type=int,
+        help="number of epochs to train", default=10000)
 parser.add_argument("-eval_epoch", type=int,
         help="epochs between evaluation of test performance", default=10)
 
@@ -54,10 +58,10 @@ def get_nonlin(nonlin):
     elif nonlin == 'tanh':
         return lasagne.nonlinearities.tanh
     else:
-        raise ValueError()
+        raise ValueError('invalid non-linearity \'' + nonlin + '\'')
 
 iw_samples = args.iw_samples   #number of importance weighted samples
-eq_samples = args.eq_samples   #number of MC samples over the expectation over E_q(z|x)
+eq_samples = args.eq_samples   #number of samples for the expectation over E_q(z|x)
 lr = args.lr
 anneal_lr_factor = args.anneal_lr_factor
 anneal_lr_epoch = args.anneal_lr_epoch
@@ -69,8 +73,7 @@ nhidden = args.nhidden
 latent_size = args.nlatent
 dataset = args.dataset
 batch_size = args.batch_size
-num_epochs = 10000
-batch_size_test = 50
+num_epochs = args.nepochs
 eval_epoch = args.eval_epoch
 
 assert dataset in ['sample','fixed'], "dataset must be sample|fixed"
@@ -91,11 +94,9 @@ for name, val in sorted_args:
     description.append("# " + name + ":\t" + str(val))
 description.append('######################################################')
 
-scriptpath = os.path.realpath(__file__)
-filename = os.path.basename(scriptpath)
-shutil.copy(scriptpath,res_out + '/' + filename)
-logfile = res_out + '/logfile.log'
-model_out = res_out + '/model'
+shutil.copy(os.path.realpath(__file__), os.path.join(res_out, filename_script))
+logfile = os.path.join(res_out, 'logfile.log')
+model_out = os.path.join(res_out, 'model')
 with open(logfile,'w') as f:
     for l in description:
         f.write(l + '\n')
@@ -124,13 +125,17 @@ else:
 
 
 train_x = np.concatenate([train_x,valid_x])
+
+train_x = train_x.astype(theano.config.floatX)
+test_x = test_x.astype(theano.config.floatX)
+
 num_features=train_x.shape[-1]
 
-sh_x_train = theano.shared(np.asarray(preprocesses_dataset(train_x), dtype=theano.config.floatX), borrow=True)
-sh_x_test = theano.shared(np.asarray(preprocesses_dataset(test_x), dtype=theano.config.floatX), borrow=True)
+sh_x_train = theano.shared(preprocesses_dataset(train_x), borrow=True)
+sh_x_test = theano.shared(preprocesses_dataset(test_x), borrow=True)
 
-#dummy test data for testing the implementation
-X = np.ones((batch_size,784),dtype='float32')
+#dummy test data for testing the implementation (printing output shapes of intermediate layers)
+X = np.ones((batch_size, 784), dtype=theano.config.floatX)
 
 
 def batchnormlayer(l,num_units, nonlinearity, name, W=lasagne.init.GlorotUniform(), b=lasagne.init.Constant(0.)):
@@ -188,27 +193,26 @@ def latent_gaussian_x_bernoulli(z, z_mu, z_log_var, x_mu, x, eq_samples, iw_samp
 
     When the output is bernoulli then the output from the decoder
     should be sigmoid. The sizes of the inputs are
-    z: (batch_size*Eq_samples*ivae_samples*nsamples, num_latent)
+    z: (batch_size*eq_samples*iw_samples, num_latent)
     z_mu: (batch_size, num_latent)
     z_log_var: (batch_size, num_latent)
-    x_mu: (batch_size*Eq_samples*ivae_samples*nsamples, num_latent)
+    x_mu: (batch_size*eq_samples*iw_samples, num_features)
     x: (batch_size, num_features)
 
-    Reference: Burda et. al. 2015 "Importance Weighted Autoencoders"
-
+    Reference: Burda et al. 2015 "Importance Weighted Autoencoders"
     """
 
     # reshape the variables so batch_size, eq_samples and iw_samples are separate dimensions
-    z = z.reshape((-1, eq_samples, iw_samples,  latent_size))
-    x_mu = x_mu.reshape((-1, eq_samples, iw_samples,  num_features))
+    z = z.reshape((-1, eq_samples, iw_samples, latent_size))
+    x_mu = x_mu.reshape((-1, eq_samples, iw_samples, num_features))
 
-    # dimshuffle x since we need to broadcast it when calculationg the binary
-    # cross-entropy
-    x = x.dimshuffle(0,'x','x',1) # x: (batch_size, eq_samples, iw_samples, num_latent)
+    # dimshuffle x, z_mu and z_log_var since we need to broadcast them when calculating the pdfs
+    x = x.dimshuffle(0,'x','x',1)                   # size: (batch_size, eq_samples, iw_samples, num_features)
+    z_mu = z_mu.dimshuffle(0,'x','x',1)             # size: (batch_size, eq_samples, iw_samples, num_latent)
+    z_log_var = z_log_var.dimshuffle(0,'x','x',1)   # size: (batch_size, eq_samples, iw_samples, num_latent)
 
-    #calculate LL components, note that we sum over the feature/num_unit dimension
-    z_mu = z_mu.dimshuffle(0,'x','x',1) # mean: (batch_size, num_latent)
-    z_log_var = z_log_var.dimshuffle(0,'x','x',1) # logvar: (batch_size, num_latent)
+    # calculate LL components, note that the log_xyz() functions return log prob. for indepenedent components separately 
+    # so we sum over feature/latent dimensions for multivariate pdfs
     log_qz_given_x = log_normal2(z, z_mu, z_log_var).sum(axis=3)
     log_pz = log_stdnormal(z).sum(axis=3)
     log_px_given_z = log_bernoulli(x, T.clip(x_mu,epsilon,1-epsilon)).sum(axis=3)
@@ -218,17 +222,19 @@ def latent_gaussian_x_bernoulli(z, z_mu, z_log_var, x_mu, x, eq_samples, iw_samp
     a = log_pz + log_px_given_z - log_qz_given_x    # size: (batch_size, eq_samples, iw_samples)
     a_max = T.max(a, axis=2, keepdims=True)         # size: (batch_size, eq_samples, 1)
 
-    # LL is calculated using Eq (8) in burda et al.
+    # LL is calculated using Eq (8) in Burda et al.
     # Working from inside out of the calculation below:
-    # T.exp(a-a_max): (bathc_size, Eq_samples, iw_samples)
+    # T.exp(a-a_max): (batch_size, eq_samples, iw_samples)
     # -> subtract a_max to avoid overflow. a_max is specific for  each set of
-    # importance samples and is broadcoasted over the last dimension.
+    # importance samples and is broadcasted over the last dimension.
     #
-    # T.log( T.mean(T.exp(a-a_max), axis=2): (batch_size, Eq_samples)
+    # T.log( T.mean(T.exp(a-a_max), axis=2) ): (batch_size, eq_samples)
     # -> This is the log of the sum over the importance weighted samples
     #
+    # The outer T.mean() computes the mean over eq_samples and batch_size
+    #
     # Lastly we add T.mean(a_max) to correct for the log-sum-exp trick
-    LL = T.mean(a_max) + T.mean( T.log( T.mean(T.exp(a-a_max), axis=2)))
+    LL = T.mean(a_max) + T.mean( T.log( T.mean(T.exp(a-a_max), axis=2) ) )
 
     return LL, T.mean(log_qz_given_x), T.mean(log_pz), T.mean(log_px_given_z)
 
@@ -249,7 +255,7 @@ print "OUTPUT SIZE OF l_z using BS=%i, sym_iw_samples=%i, sym_Eq_samples=%i --"\
 print "log_pz_train", log_pz_train.eval({sym_x:X, sym_iw_samples: np.int32(iw_samples),sym_eq_samples:np.int32(eq_samples)}).shape
 print "log_px_given_z_train", log_px_given_z_train.eval({sym_x:X, sym_iw_samples: np.int32(iw_samples), sym_eq_samples:np.int32(eq_samples)}).shape
 print "log_qz_given_x_train", log_qz_given_x_train.eval({sym_x:X, sym_iw_samples: np.int32(iw_samples), sym_eq_samples:np.int32(eq_samples)}).shape
-print "lower_bound_train", LL_train.eval({sym_x:X, sym_iw_samples: np.int32(iw_samples), sym_eq_samples:np.int32(eq_samples)})
+print "lower_bound_train", LL_train.eval({sym_x:X, sym_iw_samples: np.int32(iw_samples), sym_eq_samples:np.int32(eq_samples)}).shape
 
 # get all parameters
 params = lasagne.layers.get_all_params([l_dec_x_mu], trainable=True)
@@ -284,15 +290,12 @@ if batch_norm:
                                 [collect_out],
                                 givens={sym_x: sh_x_train})
 
-
-n_train_batches = train_x.shape[0] / batch_size
-n_test_batches = test_x.shape[0] / batch_size_test
-
 # Training and Testing functions
-def train_epoch(lr,nsamples,ivae_samples):
+def train_epoch(lr, eq_samples, iw_samples, batch_size):
+    n_train_batches = train_x.shape[0] / batch_size
     costs, log_qz_given_x,log_pz,log_px_given_z, z_mu_train, z_log_var_train  = [],[],[],[],[],[]
     for i in range(n_train_batches):
-        cost_batch, log_qz_given_x_batch, log_pz_batch, log_px_given_z_batch, z_mu_batch, z_log_var_batch = train_model(i,batch_size,lr,nsamples,ivae_samples)
+        cost_batch, log_qz_given_x_batch, log_pz_batch, log_px_given_z_batch, z_mu_batch, z_log_var_batch = train_model(i, batch_size, lr, eq_samples, iw_samples)
         costs += [cost_batch]
         log_qz_given_x += [log_qz_given_x_batch]
         log_pz += [log_pz_batch]
@@ -301,12 +304,13 @@ def train_epoch(lr,nsamples,ivae_samples):
         z_log_var_train += [z_log_var_batch]
     return np.mean(costs), np.mean(log_qz_given_x), np.mean(log_pz), np.mean(log_px_given_z), np.concatenate(z_mu_train), np.concatenate(z_log_var_train)
 
-def test_epoch(nsamples,ivae_samples):
+def test_epoch(eq_samples, iw_samples, batch_size):
     if batch_norm:
         _ = f_collect(1,1) #collect BN stats on train
+    n_test_batches = test_x.shape[0] / batch_size
     costs, log_qz_given_x,log_pz,log_px_given_z, z_mu_train = [],[],[],[],[]
     for i in range(n_test_batches):
-        cost_batch, log_qz_given_x_batch, log_pz_batch, log_px_given_z_batch = test_model(i,batch_size_test,nsamples,ivae_samples)
+        cost_batch, log_qz_given_x_batch, log_pz_batch, log_px_given_z_batch = test_model(i, batch_size, eq_samples, iw_samples)
         costs += [cost_batch]
         log_qz_given_x += [log_qz_given_x_batch]
         log_pz += [log_pz_batch]
@@ -323,13 +327,13 @@ LL_test1, log_qz_given_x_test1, log_pz_test1, log_px_given_z_test1 = [],[],[],[]
 LL_test5000, log_qz_given_x_test5000, log_pz_test5000, log_px_given_z_test5000 = [],[],[],[]
 xepochs = []
 logvar_z_mu_train, logvar_z_var_train, meanvar_z_var_train = None,None,None
-for epoch in range(1,num_epochs):
+for epoch in range(1, 1+num_epochs):
     start = time.time()
 
     #shuffle train data and train model
     np.random.shuffle(train_x)
     sh_x_train.set_value(preprocesses_dataset(train_x))
-    train_out = train_epoch(lr,eq_samples, iw_samples)
+    train_out = train_epoch(lr, eq_samples, iw_samples, batch_size)
 
     if np.isnan(train_out[0]):
         ValueError("NAN in train LL!")
@@ -348,13 +352,13 @@ for epoch in range(1,num_epochs):
         z_log_var_train = train_out[5]
 
         print "calculating LL eq=1, iw=5000"
-        test_out5000 = test_epoch(1, 5000)
+        test_out5000 = test_epoch(1, 5000, batch_size=5) # smaller batch size to reduce memory requirements
         LL_test5000 += [test_out5000[0]]
         log_qz_given_x_test5000 += [test_out5000[1]]
         log_pz_test5000 += [test_out5000[2]]
         log_px_given_z_test5000 += [test_out5000[3]]
         print "calculating LL eq=1, iw=1"
-        test_out1 = test_epoch(1, 1)
+        test_out1 = test_epoch(1, 1, batch_size=50)
         LL_test1 += [test_out1[0]]
         log_qz_given_x_test1 += [test_out1[1]]
         log_pz_test1 += [test_out1[2]]
@@ -362,7 +366,7 @@ for epoch in range(1,num_epochs):
 
         xepochs += [epoch]
 
-        line = "*Epoch=%i\tTime=%0.2f\tLR=%0.5f\tE_qsamples=%i\tIVAEsamples=%i\t" %(epoch, t, lr, eq_samples, iw_samples) + \
+        line = "*Epoch=%i\tTime=%0.2f\tLR=%0.5f\teq_samples=%i\tiw_samples=%i\t" %(epoch, t, lr, eq_samples, iw_samples) + \
             "TRAIN:\tCost=%0.5f\tlogq(z|x)=%0.5f\tlogp(z)=%0.5f\tlogp(x|z)=%0.5f\t" %(costs_train[-1], log_qz_given_x_train[-1], log_pz_train[-1], log_px_given_z_train[-1]) + \
             "EVAL-L1:\tCost=%0.5f\tlogq(z|x)=%0.5f\tlogp(z)=%0.5f\tlogp(x|z)=%0.5f\t" %(LL_test1[-1], log_qz_given_x_test1[-1], log_pz_test1[-1], log_px_given_z_test1[-1]) + \
             "EVAL-L5000:\tCost=%0.5f\tlogq(z|x)=%0.5f\tlogp(z)=%0.5f\tlogp(x|z)=%0.5f\t" %(LL_test5000[-1], log_qz_given_x_test5000[-1], log_pz_test5000[-1], log_px_given_z_test5000[-1])

--- a/examples/mnist_ladder.py
+++ b/examples/mnist_ladder.py
@@ -66,6 +66,8 @@ class RasmusInit(lasagne.init.Initializer):
                       np.sqrt(shape[0]))
 
 
+filename_script = os.path.basename(os.path.realpath(__file__))
+
 import argparse
 parser = argparse.ArgumentParser()
 parser.add_argument("-lambdas", type=str,
@@ -73,7 +75,7 @@ parser.add_argument("-lambdas", type=str,
 parser.add_argument("-lr", type=str, default='0.001')
 parser.add_argument("-optimizer", type=str, default='adam')
 parser.add_argument("-init", type=str, default='None')
-parser.add_argument("-initval", type=str, default='relu')
+parser.add_argument("-initval", type=str, default='None')
 parser.add_argument("-gradclip", type=str, default='1')
 args = parser.parse_args()
 
@@ -84,7 +86,7 @@ num_labels = 100
 
 np.random.seed(1234) # reproducibility
 
-output_folder = "logs/mnist_ladder" + str(uuid.uuid4())[:18].replace('-', '_')
+output_folder = os.path.join("results", os.path.splitext(filename_script)[0] + str(uuid.uuid4())[:18].replace('-', '_'))
 if not os.path.exists(output_folder):
     os.makedirs(output_folder)
 output_file = os.path.join(output_folder, 'results.log')
@@ -107,10 +109,17 @@ optimizer = optimizers[args.optimizer]
 if args.init == 'None':  # default to antti rasmus init
     init = RasmusInit()
 else:
-    initval = float(args.initval)
-    inits = {'he': lasagne.init.HeUniform(initval),
-             'glorot': lasagne.init.GlorotUniform(initval),
-             'normal': lasagne.init.Normal(initval)}
+    if args.initval != 'None':
+        # if `-initval` is not `'None'` use it as first argument to Lasange initializer
+        initargs = [float(args.initval)]
+    else:
+        # use default arguments for Lasange initializers
+        initargs = []
+
+    inits = {'he': lasagne.init.HeUniform(*initargs),
+             'glorot': lasagne.init.GlorotUniform(*initargs),
+             'uniform': lasagne.init.Uniform(*initargs),
+             'normal': lasagne.init.Normal(*initargs)}
     init = inits[args.init]
 
 

--- a/examples/vae_vanilla.py
+++ b/examples/vae_vanilla.py
@@ -7,11 +7,13 @@ import numpy as np
 import lasagne
 from parmesan.distributions import log_stdnormal, log_normal2, log_bernoulli, kl_normal2_stdnormal
 from parmesan.layers import SimpleSampleLayer
-from parmesan.datasets import load_mnist_realval
+from parmesan.datasets import load_mnist_realval, load_mnist_binarized
 import time, shutil, os
 
+filename_script = os.path.basename(os.path.realpath(__file__))
 
 #settings
+dataset = 'fixed'
 batch_size = 100
 nhidden = 200
 nonlin_enc = T.nnet.softplus
@@ -20,18 +22,15 @@ latent_size = 100
 analytic_kl_term = True
 lr = 0.0003
 num_epochs = 1000
-results_out = 'results/vae_vanilla/'
+results_out = os.path.join("results", os.path.splitext(filename_script)[0])
 
 np.random.seed(1234) # reproducibility
 
 # Setup outputfolder logfile etc.
 if not os.path.exists(results_out):
     os.makedirs(results_out)
-scriptpath = os.path.realpath(__file__)
-filename = os.path.basename(scriptpath)
-shutil.copy(scriptpath,results_out + filename)
-logfile = results_out + 'logfile.log'
-model_out = results_out + 'model'
+shutil.copy(os.path.realpath(__file__), os.path.join(results_out, filename_script))
+logfile = os.path.join(results_out, 'logfile.log')
 
 #SYMBOLIC VARS
 sym_x = T.matrix()
@@ -44,18 +43,29 @@ def bernoullisample(x):
 
 
 ### LOAD DATA
-train_x, train_t, valid_x, valid_t, test_x, test_t = load_mnist_realval()
+if dataset is 'sample':
+    print "Using real valued MNIST dataset to binomial sample dataset after every epoch "
+    train_x, train_t, valid_x, valid_t, test_x, test_t = load_mnist_realval()
+    del train_t, valid_t, test_t
+    preprocesses_dataset = bernoullisample
+else:
+    print "Using fixed binarized MNIST data"
+    train_x, valid_x, test_x = load_mnist_binarized()
+    preprocesses_dataset = lambda dataset: dataset #just a dummy function
+
 #concatenate train and validation set
 train_x = np.concatenate([train_x, valid_x])
+
+train_x = train_x.astype(theano.config.floatX)
+test_x = test_x.astype(theano.config.floatX)
 
 nfeatures=train_x.shape[1]
 n_train_batches = train_x.shape[0] / batch_size
 n_test_batches = test_x.shape[0] / batch_size
 
 #setup shared variables
-sh_x_train = theano.shared(np.asarray(bernoullisample(train_x), dtype=theano.config.floatX), borrow=True)
-sh_x_test = theano.shared(np.asarray(bernoullisample(test_x), dtype=theano.config.floatX), borrow=True)
-
+sh_x_train = theano.shared(preprocesses_dataset(train_x), borrow=True)
+sh_x_test = theano.shared(preprocesses_dataset(test_x), borrow=True)
 
 ### RECOGNITION MODEL q(z|x)
 l_in = lasagne.layers.InputLayer((batch_size, nfeatures))
@@ -86,14 +96,19 @@ z_eval, z_mu_eval, z_log_var_eval, x_mu_eval = lasagne.layers.get_output(
 )
 
 
-#Calculate the loglikelihood(x) = E_q[ log(x|z) + p(z) - q(z|x)]
-def latent_gaussian_x_bernoulli(z, z_mu, z_log_var, x, x_mu, analytic_kl_term):
+#Calculate the loglikelihood(x) = E_q[ log p(x|z) + log p(z) - log q(z|x)]
+def latent_gaussian_x_bernoulli(z, z_mu, z_log_var, x_mu, x, analytic_kl_term):
     """
     Latent z       : gaussian with standard normal prior
     decoder output : bernoulli
 
     When the output is bernoulli then the output from the decoder
-    should be sigmoid.
+    should be sigmoid. The sizes of the inputs are
+    z: (batch_size, num_latent)
+    z_mu: (batch_size, num_latent)
+    z_log_var: (batch_size, num_latent)
+    x_mu: (batch_size, num_features)
+    x: (batch_size, num_features)
     """
     if analytic_kl_term:
         kl_term = kl_normal2_stdnormal(z_mu, z_log_var).sum(axis=1)
@@ -108,11 +123,11 @@ def latent_gaussian_x_bernoulli(z, z_mu, z_log_var, x, x_mu, analytic_kl_term):
 
 # TRAINING LogLikelihood
 LL_train = latent_gaussian_x_bernoulli(
-    z_train, z_mu_train, z_log_var_train, sym_x, x_mu_train, analytic_kl_term)
+    z_train, z_mu_train, z_log_var_train, x_mu_train, sym_x, analytic_kl_term)
 
 # EVAL LogLikelihood
 LL_eval = latent_gaussian_x_bernoulli(
-    z_eval, z_mu_eval, z_log_var_eval, sym_x, x_mu_eval, analytic_kl_term)
+    z_eval, z_mu_eval, z_log_var_eval, x_mu_eval, sym_x, analytic_kl_term)
 
 
 params = lasagne.layers.get_all_params([l_dec_x_mu], trainable=True)
@@ -162,9 +177,16 @@ def test_epoch():
 # Training Loop
 for epoch in range(num_epochs):
     start = time.time()
+
+    #shuffle train data, train model and test model
+    np.random.shuffle(train_x)
+    sh_x_train.set_value(preprocesses_dataset(train_x))
+
     train_cost = train_epoch(lr)
     test_cost = test_epoch()
+
     t = time.time() - start
+
     line =  "*Epoch: %i\tTime: %0.2f\tLR: %0.5f\tLL Train: %0.3f\tLL test: %0.3f\t" % ( epoch, t, lr, train_cost, test_cost)
     print line
     with open(logfile,'a') as f:


### PR DESCRIPTION
Fixes a number of small issues with the examples
- Inconsistent output folders across different examples
- Some help strings for `argparse` were not very helpful
- Some options (like number of training epochs) were not settable through command
line
- In the `mnist_ladder` example, default value for command line argument `-initval` was
`'relu'` while it should be a numeric value which depends on `-init`
(changed to `'None'` meaning Lasagne default)
- Some comments regarding tensor sizes were incorrect or inconsistent
- Reduced batch size when estimating test log likelihood using 5k point
importance sampling, to reduce memory requirements on smaller GPUs (e.g.
5000 (iw_samples) x 1 (eq_samples) x 50 (batch_size) x 784 (num_features) x 4 bytes is
approx. 748 MB)
- Actual number of epochs trained would be one less than specified in
some examples
- Added input shuffling for `vae_vanilla` training like other examples
- Some minor clean ups