### PR TITLE
fixes performance in iw examples

### DIFF
--- a/examples/iw_vae.py
+++ b/examples/iw_vae.py
@@ -15,13 +15,17 @@ import shutil, gzip, os, cPickle, time, math, operator, argparse
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-dataset", type=str,
-        help="real or binarized MNIST, real|binarized", default="real")
+        help="sampled or fixed binarized MNIST, sample|fixed", default="sample")
 parser.add_argument("-eq_samples", type=int,
         help="samples over Eq", default=1)
 parser.add_argument("-iw_samples", type=int,
         help="iw_samples", default=1)
 parser.add_argument("-lr", type=float,
-        help="lr", default=0.001)
+        help="learning rate", default=0.001)
+parser.add_argument("-anneal_lr_factor", type=float,
+        help="learning rate annealing factor", default=0.999)
+parser.add_argument("-anneal_lr_epoch", type=float,
+        help="larning rate annealing start epoch", default=1000)
 parser.add_argument("-outfolder", type=str,
         help="outfolder", default="outfolder")
 parser.add_argument("-nonlin_enc", type=str,
@@ -29,11 +33,11 @@ parser.add_argument("-nonlin_enc", type=str,
 parser.add_argument("-nonlin_dec", type=str,
         help="nonlin decoder", default="rectify")
 parser.add_argument("-nhidden", type=int,
-        help="number of hidden units in determistic layers", default=200)
+        help="number of hidden units in determistic layers", default=500)
 parser.add_argument("-nlatent", type=int,
-        help="number of stochastic latent units", default=50)
+        help="number of stochastic latent units", default=100)
 parser.add_argument("-batch_size", type=int,
-        help="batch size", default=250)
+        help="batch size", default=100)
 parser.add_argument("-eval_epoch", type=int,
         help="epochs between evaluation of test performance", default=10)
 
@@ -53,6 +57,8 @@ def get_nonlin(nonlin):
 iw_samples = args.iw_samples   #number of importance weighted samples
 eq_samples = args.eq_samples   #number of MC samples over the expectation over E_q(z|x)
 lr = args.lr
+anneal_lr_factor = args.anneal_lr_factor
+anneal_lr_epoch = args.anneal_lr_epoch
 res_out = args.outfolder
 nonlin_enc = get_nonlin(args.nonlin_enc)
 nonlin_dec = get_nonlin(args.nonlin_dec)
@@ -64,7 +70,7 @@ num_epochs = 10000
 batch_size_test = 50
 eval_epoch = args.eval_epoch
 
-assert dataset in ['real','binarized'], "dataset must be real|binarized"
+assert dataset in ['sample','fixed'], "dataset must be sample|fixed"
 
 np.random.seed(1234) # reproducibility
 
@@ -103,7 +109,7 @@ def bernoullisample(x):
 
 
 ### LOAD DATA AND SET UP SHARED VARIABLES
-if dataset is 'real':
+if dataset is 'sample':
     print "Using real valued MNIST dataset to binomial sample dataset after every epoch "
     train_x, train_t, valid_x, valid_t, test_x, test_t = load_mnist_realval()
     del train_t, valid_t, test_t
@@ -292,9 +298,12 @@ for epoch in range(1,num_epochs):
     sh_x_train.set_value(preprocesses_dataset(train_x))
     train_out = train_epoch(lr,eq_samples, iw_samples)
 
-
     if np.isnan(train_out[0]):
         ValueError("NAN in train LL!")
+
+    if epoch >= anneal_lr_epoch:
+        #annealing learning rate
+        lr = lr*anneal_lr_factor
 
     if epoch % eval_epoch == 0:
         t = time.time() - start
@@ -335,7 +344,7 @@ for epoch in range(1,num_epochs):
             cPickle.dump(all_params, f, protocol=cPickle.HIGHEST_PROTOCOL)
             f.close()
 
-        # BELOW THIS LINE IS A LOT OF BOOKING AND PLOTTING OF RESULTS
+        # BELOW THIS LINE IS A LOT OF BOOK KEEPING AND PLOTTING OF RESULTS
         _logvar_z_mu_train = np.log(np.var(z_mu_train,axis=0))
         _logvar_z_var_train = np.log(np.var(np.exp(z_log_var_train),axis=0))
         _meanvar_z_var_train = np.log(np.mean(np.exp(z_log_var_train),axis=0))


### PR DESCRIPTION
This should fix the performance issues reported in #18 for iw_vae.py and iw_vae_normflow.py

Fixes:
- naming of sampling procedure  (real | binarized) -> (sample | binarized)
- accidental switch of the sampling procedure
- better default values of hyper params 
