### PR TITLE
Naming

### DIFF
--- a/parmesan/distributions.py
+++ b/parmesan/distributions.py
@@ -93,7 +93,7 @@ def log_multinomial(x, p):
     """
     Compute log pdf of multinomial distribution
 
-        .. math:: \log p(x; p) = \log \sum_x p(x) \log q(x)
+        .. math:: \log p(x; p) = \sum_x p(x) \log q(x)
 
     where p is the true class probability and q is the predicted class
     probability.

--- a/parmesan/distributions.py
+++ b/parmesan/distributions.py
@@ -1,8 +1,8 @@
 import math
 import theano.tensor as T
-
-
 c = - 0.5 * math.log(2*math.pi)
+
+
 def log_normal(x, mean, sd):
     """
     Compute log pdf of a Gaussian distribution with diagonal covariance, at values x.
@@ -25,7 +25,8 @@ def log_normal(x, mean, sd):
     """
     return c - T.log(T.abs_(sd)) - (x - mean)**2 / (2 * sd**2)
 
-def log_normal2(x, mean, logvar):
+
+def log_normal2(x, mean, log_var):
     """
     Compute log pdf of a Gaussian distribution with diagonal covariance, at values x.
     Here variance is parameterized in the log domain, which ensures :math:`\sigma > 0`.
@@ -38,7 +39,7 @@ def log_normal2(x, mean, logvar):
         Values at which to evaluate pdf.
     mean : Theano tensor
         Mean of the Gaussian distribution.
-    logvar : Theano tensor
+    log_var : Theano tensor
         Log variance of the diagonal covariance Gaussian.
 
     Returns
@@ -46,7 +47,7 @@ def log_normal2(x, mean, logvar):
     Theano tensor
         Element-wise log probability, this has to be summed for multi-variate distributions.
     """
-    return c - logvar/2 - (x - mean)**2 / (2 * T.exp(logvar))
+    return c - log_var/2 - (x - mean)**2 / (2 * T.exp(log_var))
 
 def log_stdnormal(x):
     """
@@ -65,6 +66,7 @@ def log_stdnormal(x):
         Element-wise log probability, this has to be summed for multi-variate distributions.
     """
     return c - x**2 / 2
+
 
 def log_bernoulli(x, p):
     """
@@ -86,7 +88,34 @@ def log_bernoulli(x, p):
     """
     return -T.nnet.binary_crossentropy(p, x)
 
-def kl_normal2_stdnormal(mean, logvar):
+
+def log_multinomial(x, p):
+    """
+    Compute log pdf of multinomial distribution
+
+        .. math:: \log p(x; p) = \log \sum_x p(x) \log q(x)
+
+    where p is the true class probability and q is the predicted class
+    probability.
+
+
+    Parameters
+    ----------
+    x : Theano tensor
+        Values at which to evaluate pdf. Either an integer vector or a
+        samples by class matrix with class probabilities.
+    p : Theano tensor
+        Samples by class matrix with predicted class probabilities
+
+    Returns
+    -------
+    Theano tensor
+        Element-wise log probability
+    """
+    return -T.nnet.categorical_crossentropy(p, x)
+
+
+def kl_normal2_stdnormal(mean, log_var):
     """
     Compute analytically integrated KL-divergence between a diagonal covariance Gaussian and 
     a standard Gaussian.
@@ -103,7 +132,7 @@ def kl_normal2_stdnormal(mean, logvar):
     ----------
     mean : Theano tensor
         Mean of the diagonal covariance Gaussian.
-    logvar : Theano tensor
+    log_var : Theano tensor
         Log variance of the diagonal covariance Gaussian.
 
     Returns
@@ -118,4 +147,4 @@ def kl_normal2_stdnormal(mean, logvar):
             arXiv preprint arXiv:1312.6114 (2013).
 
     """
-    return -0.5*(1 + logvar - mean**2 - T.exp(logvar))
+    return -0.5*(1 + log_var - mean**2 - T.exp(log_var))

--- a/parmesan/layers/sample.py
+++ b/parmesan/layers/sample.py
@@ -21,8 +21,8 @@ class SimpleSampleLayer(lasagne.layers.MergeLayer):
             "Auto-Encoding Variational Bayes."
             arXiv preprint arXiv:1312.6114 (2013).
     """
-    def __init__(self, mu, log_var, **kwargs):
-        super(SimpleSampleLayer, self).__init__([mu, log_var], **kwargs)
+    def __init__(self, mean, log_var, **kwargs):
+        super(SimpleSampleLayer, self).__init__([mean, log_var], **kwargs)
 
         self._srng = RandomStreams(
             lasagne.random.get_rng().randint(1, 2147462579))
@@ -79,8 +79,9 @@ class SampleLayer(lasagne.layers.MergeLayer):
             arXiv preprint arXiv:1509.00519 (2015).
     """
 
-    def __init__(self, mu, log_var, eq_samples=1, iw_samples=1, nonlinearity=lambda x: T.exp(0.5*x),  **kwargs):
-        super(SampleLayer, self).__init__([mu, log_var], **kwargs)
+    def __init__(self, mean, log_var, eq_samples=1, iw_samples=1,
+                 nonlinearity=lambda x: T.exp(0.5*x),  **kwargs):
+        super(SampleLayer, self).__init__([mean, log_var], **kwargs)
 
         self.eq_samples = eq_samples
         self.iw_samples = iw_samples


### PR DESCRIPTION
- Adds multinomial cost  (please check :))
- rename `mu` to `mean` across all classes. This matches numpy. 
- use 'log_var' in all classes
- Fix typo in confusion matrix batchaddmasked method
- some pep8 changes.