### PR TITLE
Some additional helper functions

### DIFF
--- a/examples/vae_vanilla.py
+++ b/examples/vae_vanilla.py
@@ -112,12 +112,12 @@ def latent_gaussian_x_bernoulli(z, z_mu, z_log_var, x_mu, x, analytic_kl_term):
     """
     if analytic_kl_term:
         kl_term = kl_normal2_stdnormal(z_mu, z_log_var).sum(axis=1)
-        log_px_given_z = log_bernoulli(x, x_mu,  eps=1e-6).sum(axis=1)
+        log_px_given_z = log_bernoulli(x, x_mu, epsilon=1e-6).sum(axis=1)
         LL = T.mean(-kl_term + log_px_given_z)
     else:
         log_qz_given_x = log_normal2(z, z_mu, z_log_var).sum(axis=1)
         log_pz = log_stdnormal(z).sum(axis=1)
-        log_px_given_z = log_bernoulli(x, x_mu,  eps=1e-6).sum(axis=1)
+        log_px_given_z = log_bernoulli(x, x_mu, epsilon=1e-6).sum(axis=1)
         LL = T.mean(log_pz + log_px_given_z - log_qz_given_x)
     return LL
 

--- a/examples/vae_vanilla.py
+++ b/examples/vae_vanilla.py
@@ -112,12 +112,12 @@ def latent_gaussian_x_bernoulli(z, z_mu, z_log_var, x_mu, x, analytic_kl_term):
     """
     if analytic_kl_term:
         kl_term = kl_normal2_stdnormal(z_mu, z_log_var).sum(axis=1)
-        log_px_given_z = log_bernoulli(x, x_mu, epsilon=1e-6).sum(axis=1)
+        log_px_given_z = log_bernoulli(x, x_mu, eps=1e-6).sum(axis=1)
         LL = T.mean(-kl_term + log_px_given_z)
     else:
         log_qz_given_x = log_normal2(z, z_mu, z_log_var).sum(axis=1)
         log_pz = log_stdnormal(z).sum(axis=1)
-        log_px_given_z = log_bernoulli(x, x_mu, epsilon=1e-6).sum(axis=1)
+        log_px_given_z = log_bernoulli(x, x_mu, eps=1e-6).sum(axis=1)
         LL = T.mean(log_pz + log_px_given_z - log_qz_given_x)
     return LL
 

--- a/parmesan/distributions.py
+++ b/parmesan/distributions.py
@@ -201,3 +201,34 @@ def kl_normal2_stdnormal(mean, log_var):
             arXiv preprint arXiv:1312.6114 (2013).
     """
     return -0.5*(1 + log_var - mean**2 - T.exp(log_var))
+
+def kl_normal2_normal2(mean1, log_var1, mean2, log_var2):
+    """
+    Compute analytically integrated KL-divergence between two diagonal covariance Gaussians.
+
+    .. math::
+
+       D_{KL}[q||p] &= -\int p(x) \log q(x) dx + \int p(x) \log p(x) dx     \\
+                    &= -\int \mathcal{N}(x; \mu_2, \sigma^2_2) \log \mathcal{N}(x; \mu_1, \sigma^2_1) dx
+                        + \int \mathcal{N}(x; \mu_2, \sigma^2_2) \log \mathcal{N}(x; \mu_2, \sigma^2_2) dx     \\
+                    &= \frac{1}{2} \log(2\pi\sigma^2_2) + \frac{\sigma^2_1 + (\mu_1 - \mu_2)^2}{2\sigma^2_2} 
+                        - \frac{1}{2}( 1 + \log(2\pi\sigma^2_1) )      \\
+                    &= \log \frac{\sigma_2}{\sigma_1} + \frac{\sigma^2_1 + (\mu_1 - \mu_2)^2}{2\sigma^2_2} - \frac{1}{2}
+
+    Parameters
+    ----------
+    mean1 : Theano tensor
+        Mean of the q Gaussian.
+    log_var1 : Theano tensor
+        Log variance of the q Gaussian.
+    mean2 : Theano tensor
+        Mean of the p Gaussian.
+    log_var2 : Theano tensor
+        Log variance of the p Gaussian.
+
+    Returns
+    -------
+    Theano tensor
+        Element-wise KL-divergence, this has to be summed when the Gaussian distributions are multi-variate.
+    """
+    return 0.5*log_var2 - 0.5*log_var1 + (T.exp(log_var1) + (mean1 - mean2)**2) / (2*T.exp(log_var2)) - 0.5

--- a/parmesan/distributions.py
+++ b/parmesan/distributions.py
@@ -6,6 +6,7 @@ c = - 0.5 * math.log(2*math.pi)
 def log_normal(x, mean, sd, eps=0.0):
     """
     Compute log pdf of a Gaussian distribution with diagonal covariance, at values x.
+    Variance is parameterized as standard deviation.
 
         .. math:: \log p(x) = \log \mathcal{N}(x; \mu, \sigma^2I)
     
@@ -24,14 +25,51 @@ def log_normal(x, mean, sd, eps=0.0):
     -------
     Theano tensor
         Element-wise log probability, this has to be summed for multi-variate distributions.
+
+    See also
+    --------
+    log_normal1 : using variance parameterization
+    log_normal2 : using log variance parameterization
     """
     return c - T.log(T.abs_(sd)) - (x - mean)**2 / (2 * sd**2 + eps)
+
+
+def log_normal1(x, mean, var, eps=0.0):
+    """
+    Compute log pdf of a Gaussian distribution with diagonal covariance, at values x.
+    Variance is parameterized as variance rather than standard deviation.
+
+        .. math:: \log p(x) = \log \mathcal{N}(x; \mu, \sigma^2I)
+    
+    Parameters
+    ----------
+    x : Theano tensor
+        Values at which to evaluate pdf.
+    mean : Theano tensor
+        Mean of the Gaussian distribution.
+    var : Theano tensor
+        Variance of the diagonal covariance Gaussian.
+    eps : float
+        Small number used to avoid NaNs
+
+    Returns
+    -------
+    Theano tensor
+        Element-wise log probability, this has to be summed for multi-variate distributions.
+
+    See also
+    --------
+    log_normal : using standard deviation parameterization
+    log_normal2 : using log variance parameterization
+    """
+    var += eps
+    return c - T.log(var)/2 - (x - mean)**2 / (2*var)
 
 
 def log_normal2(x, mean, log_var, eps=0.0):
     """
     Compute log pdf of a Gaussian distribution with diagonal covariance, at values x.
-    Here variance is parameterized in the log domain, which ensures :math:`\sigma > 0`.
+    Variance is parameterized as log variance rather than standard deviation, which ensures :math:`\sigma > 0`.
 
         .. math:: \log p(x) = \log \mathcal{N}(x; \mu, \sigma^2I)
     
@@ -50,8 +88,14 @@ def log_normal2(x, mean, log_var, eps=0.0):
     -------
     Theano tensor
         Element-wise log probability, this has to be summed for multi-variate distributions.
+
+    See also
+    --------
+    log_normal : using standard deviation parameterization
+    log_normal1 : using variance parameterization
     """
     return c - log_var/2 - (x - mean)**2 / (2 * T.exp(log_var) + eps)
+
 
 def log_stdnormal(x):
     """
@@ -155,6 +199,5 @@ def kl_normal2_stdnormal(mean, log_var):
         ..  [KINGMA] Kingma, Diederik P., and Max Welling.
             "Auto-Encoding Variational Bayes."
             arXiv preprint arXiv:1312.6114 (2013).
-
     """
     return -0.5*(1 + log_var - mean**2 - T.exp(log_var))

--- a/parmesan/distributions.py
+++ b/parmesan/distributions.py
@@ -3,7 +3,7 @@ import theano.tensor as T
 c = - 0.5 * math.log(2*math.pi)
 
 
-def log_normal(x, mean, sd, eps=0.0):
+def log_normal(x, mean, std, epsilon=0.0):
     """
     Compute log pdf of a Gaussian distribution with diagonal covariance, at values x.
     Variance is parameterized as standard deviation.
@@ -16,10 +16,10 @@ def log_normal(x, mean, sd, eps=0.0):
         Values at which to evaluate pdf.
     mean : Theano tensor
         Mean of the Gaussian distribution.
-    sd : Theano tensor
+    std : Theano tensor
         Standard deviation of the diagonal covariance Gaussian.
-    eps : float
-        Small number used to avoid NaNs
+    epsilon : float
+        Small number used to avoid NaNs.
 
     Returns
     -------
@@ -31,10 +31,10 @@ def log_normal(x, mean, sd, eps=0.0):
     log_normal1 : using variance parameterization
     log_normal2 : using log variance parameterization
     """
-    return c - T.log(T.abs_(sd)) - (x - mean)**2 / (2 * sd**2 + eps)
+    return c - T.log(T.abs_(std)) - (x - mean)**2 / (2 * std**2 + epsilon)
 
 
-def log_normal1(x, mean, var, eps=0.0):
+def log_normal1(x, mean, var, epsilon=0.0):
     """
     Compute log pdf of a Gaussian distribution with diagonal covariance, at values x.
     Variance is parameterized as variance rather than standard deviation.
@@ -49,8 +49,8 @@ def log_normal1(x, mean, var, eps=0.0):
         Mean of the Gaussian distribution.
     var : Theano tensor
         Variance of the diagonal covariance Gaussian.
-    eps : float
-        Small number used to avoid NaNs
+    epsilon : float
+        Small number used to avoid NaNs.
 
     Returns
     -------
@@ -62,11 +62,11 @@ def log_normal1(x, mean, var, eps=0.0):
     log_normal : using standard deviation parameterization
     log_normal2 : using log variance parameterization
     """
-    var += eps
+    var += epsilon
     return c - T.log(var)/2 - (x - mean)**2 / (2*var)
 
 
-def log_normal2(x, mean, log_var, eps=0.0):
+def log_normal2(x, mean, log_var, epsilon=0.0):
     """
     Compute log pdf of a Gaussian distribution with diagonal covariance, at values x.
     Variance is parameterized as log variance rather than standard deviation, which ensures :math:`\sigma > 0`.
@@ -81,8 +81,8 @@ def log_normal2(x, mean, log_var, eps=0.0):
         Mean of the Gaussian distribution.
     log_var : Theano tensor
         Log variance of the diagonal covariance Gaussian.
-    eps : float
-        Small number used to avoid NaNs
+    epsilon : float
+        Small number used to avoid NaNs.
 
     Returns
     -------
@@ -94,7 +94,7 @@ def log_normal2(x, mean, log_var, eps=0.0):
     log_normal : using standard deviation parameterization
     log_normal1 : using variance parameterization
     """
-    return c - log_var/2 - (x - mean)**2 / (2 * T.exp(log_var) + eps)
+    return c - log_var/2 - (x - mean)**2 / (2 * T.exp(log_var) + epsilon)
 
 
 def log_stdnormal(x):
@@ -116,7 +116,7 @@ def log_stdnormal(x):
     return c - x**2 / 2
 
 
-def log_bernoulli(x, p, eps=0.0):
+def log_bernoulli(x, p, epsilon=0.0):
     """
     Compute log pdf of a Bernoulli distribution with success probability p, at values x.
 
@@ -128,19 +128,19 @@ def log_bernoulli(x, p, eps=0.0):
         Values at which to evaluate pdf.
     p : Theano tensor
         Success probability :math:`p(x=1)`, which is also the mean of the Bernoulli distribution.
-    eps : float
-        Small number used to avoid NaNs
+    epsilon : float
+        Small number used to avoid NaNs.
 
     Returns
     -------
     Theano tensor
         Element-wise log probability, this has to be summed for multi-variate distributions.
     """
-    p = T.clip(p, eps, 1.0 - eps)
+    p = T.clip(p, epsilon, 1.0 - epsilon)
     return -T.nnet.binary_crossentropy(p, x)
 
 
-def log_multinomial(x, p, eps=0.0):
+def log_multinomial(x, p, epsilon=0.0):
     """
     Compute log pdf of multinomial distribution
 
@@ -156,16 +156,16 @@ def log_multinomial(x, p, eps=0.0):
         Values at which to evaluate pdf. Either an integer vector or a
         samples by class matrix with class probabilities.
     p : Theano tensor
-        Samples by class matrix with predicted class probabilities
-    eps : float
-        Small number used to avoid NaNs
+        Samples by class matrix with predicted class probabilities.
+    epsilon : float
+        Small number used to avoid NaNs.
 
     Returns
     -------
     Theano tensor
-        Element-wise log probability
+        Element-wise log probability.
     """
-    p += eps
+    p += epsilon
     return -T.nnet.categorical_crossentropy(p, x)
 
 

--- a/parmesan/utils.py
+++ b/parmesan/utils.py
@@ -13,6 +13,7 @@ def log_sum_exp(A, axis=None, sum_op=T.sum):
     The log-sum-exp trick avoids these issues by using the identity,
 
     .. math::
+
         \log \sum_i \exp A_i = \log \sum_i \exp(A_i - c) + c, \text{using},  \\
         c = \max A.
 

--- a/parmesan/utils.py
+++ b/parmesan/utils.py
@@ -1,4 +1,55 @@
 import numpy as np
+import theano.tensor as T
+
+
+def log_sum_exp(A, axis=None, sum_op=T.sum):
+    """Computes `log(exp(A).sum(axis=axis))` avoiding numerical issues using the log-sum-exp trick.
+
+    Direct calculation of :math:`\log \sum_i \exp A_i` can result in underflow or overflow numerical 
+    issues. Big positive values can cause overflow :math:`\exp A_i = \inf`, and big negative values 
+    can cause underflow :math:`\exp A_i = 0`. The latter can eventually cause the sum to go to zero 
+    and finally resulting in :math:`\log 0 = -\inf`.
+
+    The log-sum-exp trick avoids these issues by using the identity,
+
+    .. math::
+        \log \sum_i \exp A_i = \log \sum_i \exp(A_i - c) + c, \text{using},  \\
+        c = \max A.
+
+    This avoids overflow, and while underflow can still happen for individual elements it avoids 
+    the sum being zero.
+     
+    Parameters
+    ----------
+    A : Theano tensor
+        Tensor of which we wish to compute the log-sum-exp.
+    axis : int, tuple, list, None
+        Axis or axes to sum over; None (default) sums over all axes.
+    sum_op : function
+        Summing function to apply; default is T.sum, but can also be T.mean for log-mean-exp.
+		
+    Returns
+    -------
+    Theano tensor
+        The log-sum-exp of `A`, dimensions over which is summed will be dropped.
+    """
+    A_max = T.max(A, axis=axis, keepdims=True)
+    B = T.log(sum_op(T.exp(A - A_max), axis=axis, keepdims=True)) + A_max
+
+    if axis is None:
+        return B.dimshuffle(())  # collapse to scalar
+    else:
+        if not hasattr(axis, '__iter__'): axis = [axis]
+        return B.dimshuffle([d for d in range(B.ndim) if d not in axis])  # drop summed axes
+
+def log_mean_exp(A, axis=None):
+    """Computes `log(exp(A).mean(axis=axis))` avoiding numerical issues using the log-sum-exp trick.
+
+    See also
+    --------
+    log_sum_exp
+    """
+    return log_sum_exp(A, axis, sum_op=T.mean)
 
 
 class ConfusionMatrix:


### PR DESCRIPTION
Extracted log-sum-exp from examples and added a log normal pdf parameterized with variance.
Also changed `sd` to `std` and `eps` to `epsilon` for consistency with lasagne and numpy.